### PR TITLE
Fix: required key not provided @ data['arch']. Got None

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "version": "0.1.2",
     "slug": "ruuvitag",
     "description": "Atmospheric information from Ruuvitag BLE sensors",
+    "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
     "startup": "application",
     "boot": "auto",
     "privileged": [


### PR DESCRIPTION
There was an error of missing key